### PR TITLE
Fix missing <sys/unistd.h> on Alpine 3.3

### DIFF
--- a/libs/Makefile
+++ b/libs/Makefile
@@ -14,7 +14,7 @@ $(PICO)/config.h:
 # (as well as static lib). The shared lib need position-independent code.
 $(PICO)/libpicosat.a: $(PICO)/config.h
 	cd $(dir $@);\
-	make CFLAGS="-fPIC $$(grep CFLAGS= Makefile | cut -d= -f2)" libpicosat.a;\
+	make CFLAGS="-fPIC $$(grep CFLAGS= makefile | cut -d= -f2)" libpicosat.a;\
 	ranlib libpicosat.a
 $(QUANT)/libquantor.a: $(QUANT)/config.h
 	cd $(dir $@);\

--- a/libs/picosat-960/picosat.c
+++ b/libs/picosat-960/picosat.c
@@ -8098,7 +8098,7 @@ picosat_stats (PS * ps)
 #ifndef NGETRUSAGE
 #include <sys/time.h>
 #include <sys/resource.h>
-#include <sys/unistd.h>
+//#include <sys/unistd.h> // How is this include useful?
 #endif
 
 double


### PR DESCRIPTION
I am trying to fix all the failing builds for the opam submission.