### PR TITLE
Opam: remove <4.11.0 requirement for running opam --with-test

### DIFF
--- a/qbf.opam
+++ b/qbf.opam
@@ -11,7 +11,7 @@ tags: [ "clib:quantor" "clib:qdpll" "clib:picosat"  ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "build" "@doc" "-p" name ] {with-doc}
-  ["dune" "runtest" "-p" name "-j" jobs] {with-test & ocaml:version < "4.11"}
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
   "ocaml" {>= "4.08"}


### PR DESCRIPTION
@kit-ty-kate has successfully been able to use --with-test, see [his comment][1].

[1]: https://github.com/ocaml/opam-repository/pull/17956#discussion_r555393460