### PR TITLE
Vendor friendly

### DIFF
--- a/src/quantor/dune
+++ b/src/quantor/dune
@@ -8,11 +8,21 @@
  (wrapped false)
  (libraries qbf)
  (flags :standard -warn-error -a+8)
- (c_library_flags :standard -lquantor -lpicosat -L.)
+ (c_library_flags :standard -lquantor -lpicosat -L%{read:cwd.txt})
  (library_flags
-  (-cclib -L.)
+  (-cclib -L%{read:cwd.txt})
   (-cclib -lquantor)
   (-cclib -lpicosat)))
+
+; This stores the absolute path to the working directory in a file cwd.txt so
+; that the linker can be passed the path to this directory and find the
+; -lquantor and -lpicosat libraries. This hack is necessary at the moment as the
+; linker is invoked from the workspace root so passing -L. or -L%{project_root}
+; won't work.
+; https://github.com/ocaml/dune/issues/7146
+(rule
+ (target cwd.txt)
+ (action (with-stdout-to cwd.txt (run pwd))))
 
 (rule
  (targets picosat.h libpicosat.a quantor.h libquantor.a)

--- a/src/quantor/dune
+++ b/src/quantor/dune
@@ -18,7 +18,7 @@
  (targets picosat.h libpicosat.a quantor.h libquantor.a)
  (action
   (progn
-   (copy %{workspace_root}/libpicosat.a libpicosat.a)
-   (copy %{workspace_root}/picosat.h picosat.h)
-   (copy %{workspace_root}/libquantor.a libquantor.a)
-   (copy %{workspace_root}/quantor.h quantor.h))))
+   (copy %{project_root}/libpicosat.a libpicosat.a)
+   (copy %{project_root}/picosat.h picosat.h)
+   (copy %{project_root}/libquantor.a libquantor.a)
+   (copy %{project_root}/quantor.h quantor.h))))


### PR DESCRIPTION
This fixes a couple of issues which prevented this package from building when vendored.

Regarding the fix to the linker arguments, see https://github.com/ocaml/dune/issues/7146 for more info.

The context for this change is making more packages able to be vendored. Read more here: https://discuss.ocaml.org/t/making-it-possible-to-vendor-an-opam-package-inside-a-dune-project/11437/1